### PR TITLE
Smokefree API runs under /api

### DIFF
--- a/src/main/java/smokefree/GraphqlController.java
+++ b/src/main/java/smokefree/GraphqlController.java
@@ -25,7 +25,7 @@ import static io.micronaut.security.rules.SecurityRule.IS_AUTHENTICATED;
 
 @Slf4j
 @Secured(IS_ANONYMOUS)
-@Controller("/graphql")
+@Controller("${micronaut.context.path:}/graphql")
 public class GraphqlController {
     @Inject
     private GraphQL graphQL;

--- a/src/main/java/smokefree/PlaygroundImportController.java
+++ b/src/main/java/smokefree/PlaygroundImportController.java
@@ -22,7 +22,7 @@ import static io.micronaut.security.rules.SecurityRule.IS_AUTHENTICATED;
 import static java.util.Collections.singletonMap;
 
 @Secured(IS_AUTHENTICATED)
-@Controller("/playgrounds")
+@Controller("${micronaut.context.path:}/playgrounds")
 public class PlaygroundImportController {
     @Inject
     Configuration configuration; // TODO: Hack for triggering Axon bootstrap

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -22,6 +22,8 @@ micronaut:
         mapping: /**
   application:
     name: smokefree-initiative-service
+  context:
+    path: /api
   security:
     enabled: true
     endpoints:


### PR DESCRIPTION
This is to keep parity between running on AWS and running locally. /api will
forward to smokefree-initiative-service, while everything else will end
up on onboarding-web.