### PR TITLE
Remove Secrets properties.

### DIFF
--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -80,6 +80,3 @@ aws:
     jdbcdriverclass: com.mysql.jdbc.Driver
 
 # AWS Secret Manager instance id and region
-secret:
-  name: MyRDSSecret-zP9lcPsgYobR
-  region: eu-west-1


### PR DESCRIPTION
Service will fail If there are no secrets properties set during service
start up itself instead of pointing secrets from bootstrap.yaml( this
will make service up and running pointing other secrets)