### PR TITLE
Expose the smokefree committed date

### DIFF
--- a/src/main/java/smokefree/domain/SmokeFreeDateCommittedEvent.java
+++ b/src/main/java/smokefree/domain/SmokeFreeDateCommittedEvent.java
@@ -3,12 +3,14 @@ package smokefree.domain;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDate;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class SmokeFreeDateCommittedEvent {
     String initiativeId;
     LocalDate previousDate;

--- a/src/main/java/smokefree/projection/Playground.java
+++ b/src/main/java/smokefree/projection/Playground.java
@@ -4,6 +4,8 @@ import lombok.Value;
 import lombok.experimental.Wither;
 import smokefree.domain.Status;
 
+import java.time.LocalDate;
+
 @Value
 @Wither
 public class Playground {
@@ -12,6 +14,7 @@ public class Playground {
     Double lat;
     Double lng;
     Status status;
+    LocalDate smokeFreeDate;
     int volunteerCount;
     int votes;
 }

--- a/src/main/resources/public/schema.graphql
+++ b/src/main/resources/public/schema.graphql
@@ -26,6 +26,7 @@ type Playground {
     lng : Float
     lat : Float
     status: Status
+    smokeFreeDate: LocalDate
     volunteerCount: Int #@auth(role : "manager")
     votes: Int
 }

--- a/src/test/java/smokefree/projection/InitiativeProjectionTest.java
+++ b/src/test/java/smokefree/projection/InitiativeProjectionTest.java
@@ -3,10 +3,13 @@ package smokefree.projection;
 import org.junit.jupiter.api.Test;
 import smokefree.domain.*;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
+import static java.time.LocalDate.now;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static smokefree.domain.Status.*;
 
 class InitiativeProjectionTest {
@@ -73,6 +76,28 @@ class InitiativeProjectionTest {
 
         projection.on(new InitiativeProgressedEvent("initiative-1", in_progress, finished));
         assertEquals(finished, projection.playground("initiative-1").getStatus());
+    }
+
+    @Test
+    void should_expose_smokefree_date_when_committed() {
+        InitiativeProjection projection = new InitiativeProjection();
+        projection.on(initiativeCreated("initiative-1", in_progress));
+        assertEquals(in_progress, projection.playground("initiative-1").getStatus());
+
+        projection.on(new InitiativeProgressedEvent("initiative-1", in_progress, finished));
+        assertEquals(finished, projection.playground("initiative-1").getStatus());
+
+        Playground playground = projection.playground("initiative-1");
+        assertNotNull(playground);
+        assertNull(playground.getSmokeFreeDate());
+
+        LocalDate today = now();
+        LocalDate tomorrow = now().plusDays(1);
+        projection.on(new SmokeFreeDateCommittedEvent("initiative-1", today, tomorrow));
+
+        playground = projection.playground("initiative-1");
+        assertEquals(finished, playground.getStatus());
+        assertEquals(tomorrow, playground.getSmokeFreeDate());
     }
 
     InitiativeCreatedEvent initiativeCreated(Status status) {


### PR DESCRIPTION
Relates to local-motion/product#151
Subtask: the new date should still show when the playground workspace is revisited in another user session