### PR TITLE
for now user profile no longer uses the projection

### DIFF
--- a/src/main/java/smokefree/Query.java
+++ b/src/main/java/smokefree/Query.java
@@ -35,10 +35,13 @@ public class Query implements GraphQLQueryResolver {
     }
 
     public Profile profile(DataFetchingEnvironment env) {
-        String userId = toContext(env).userId();
-        if (userId == null) {
-            return null;
-        }
-        return profiles.profile(userId);
+
+        // For now we do not use the profile projection (see note in that class), but retrieve the info straight from the session
+//        String userId = toContext(env).userId();
+//        if (userId == null) {
+//            return null;
+//        }
+//        return profiles.profile(userId);
+        return new Profile(toContext(env).requireUserId(), toContext(env).requireUserName());
     }
 }

--- a/src/main/java/smokefree/projection/ProfileProjection.java
+++ b/src/main/java/smokefree/projection/ProfileProjection.java
@@ -14,6 +14,16 @@ import static com.google.common.collect.Maps.newConcurrentMap;
 @Slf4j
 @Singleton
 public class ProfileProjection {
+
+
+    /*
+        TODO: Note the current implementation of this profile is no longer correct as it requires users to be volunteers (=joined a playground community)
+        which does not have to be the case.
+        At the moment this profile is not used (user info is fetched from the jwt token), but in the future this projection will be restored to use, when
+        user created events can be picked up (instead of the current initiative joined events)
+     */
+
+
     private final Map<String, Profile> profiles = newConcurrentMap();
 
     @EventHandler


### PR DESCRIPTION
projection logic is incorrect and the id and username can just be
retrieved from the jwt token