### PR TITLE
Validate playground workspace for maximum volunteers and managers

### DIFF
--- a/src/main/java/smokefree/aws/rds/secretmanager/SmokefreeConstants.java
+++ b/src/main/java/smokefree/aws/rds/secretmanager/SmokefreeConstants.java
@@ -29,7 +29,12 @@ public class SmokefreeConstants {
 		public static final String EMAIL_ADDRESS = "email";
 	}
 
-	public static final Long MAXIMUM_PLAYGROUNDS_DISTANCE = 100L;
-	public static final Long MAXIMUM_PLAYGROUNDS_ALLOWED = 1000L;
+	public static final Integer MAXIMUM_PLAYGROUNDS_DISTANCE = 100;
+	public static final Integer MAXIMUM_PLAYGROUNDS_ALLOWED = 1000;
+
+	public static class PlaygroundWorkspace {
+		public static final Integer MAXIMUM_VOLUNTEERS_ALLOWED = 200;
+		public static final Integer MAXIMUM_MANAGERS_ALLOWED = 3;
+	}
 
 }

--- a/src/main/java/smokefree/domain/Initiative.java
+++ b/src/main/java/smokefree/domain/Initiative.java
@@ -68,6 +68,7 @@ public class Initiative {
         if (citizens.contains(cmd.getCitizenId())) {
             log.warn("{} already joined {}. Ignoring...", cmd.citizenId, cmd.initiativeId);
         } else {
+            validateMaximumAllowedVolunteers();
             apply(new CitizenJoinedInitiativeEvent(cmd.initiativeId, cmd.citizenId), metaData);
         }
     }
@@ -79,6 +80,7 @@ public class Initiative {
         if (managers.contains(managerId)) {
             log.warn("{} is already managing {}. Ignoring...", managerId, cmd.initiativeId);
         } else {
+            validateMaximumAllowedManagers();
             apply(new ManagerJoinedInitiativeEvent(cmd.initiativeId, managerId), metaData);
         }
     }
@@ -252,6 +254,21 @@ public class Initiative {
                             "Two playgrounds can not exist within " + SmokefreeConstants.MAXIMUM_PLAYGROUNDS_DISTANCE+ " Meters",
                             "playground does already exists within "+ SmokefreeConstants.MAXIMUM_PLAYGROUNDS_DISTANCE+ " Meters");
                 });
+    }
+    private void validateMaximumAllowedVolunteers() {
+        if(citizens.size() >= SmokefreeConstants.PlaygroundWorkspace.MAXIMUM_VOLUNTEERS_ALLOWED) {
+            throw new DomainException("MAXIMUM_VOLUNTEERS",
+                    "No more than " + SmokefreeConstants.PlaygroundWorkspace.MAXIMUM_VOLUNTEERS_ALLOWED + " members can join the initiative" ,
+                    "No more than " + SmokefreeConstants.PlaygroundWorkspace.MAXIMUM_VOLUNTEERS_ALLOWED + " members can join the initiative");
+        }
+    }
+
+    private void validateMaximumAllowedManagers() {
+        if(managers.size() >= SmokefreeConstants.PlaygroundWorkspace.MAXIMUM_MANAGERS_ALLOWED) {
+            throw new DomainException("MAXIMUM_MANAGERS",
+                    "No more than " + SmokefreeConstants.PlaygroundWorkspace.MAXIMUM_MANAGERS_ALLOWED + " volunteers can claim for manager role",
+                    "No more than " + SmokefreeConstants.PlaygroundWorkspace.MAXIMUM_MANAGERS_ALLOWED + " volunteers can claim for manager role");
+        }
     }
 
 }


### PR DESCRIPTION
This covers only the following validations,

### Playground workspace
- the maximum number of volunteers that can enter a playground workspace is 200
- the maximum number of managers in a workspace is 3