### PR TITLE
Fix cacerts path issue during docker image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,14 @@ COPY aws/rds-combined-ca-bundle.pem /tmp/rds-ca/rds-combined-ca-bundle.pem
 RUN csplit -sz /tmp/rds-ca/rds-combined-ca-bundle.pem '/-BEGIN CERTIFICATE-/' '{*}'
 
 # import each cert individually
-RUN for CERT in xx*; do keytool -import -keystore /etc/ssl/certs/java/cacerts -storepass changeit -noprompt -alias rds$CERT -file "$CERT"; done
+RUN for CERT in xx*; do keytool -import -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit -noprompt -alias rds$CERT -file "$CERT"; done
 
 # back out of the temp dir and delete it
 RUN cd "$OLDDIR"
 RUN rm -r /tmp/rds-ca
 
 # list the imported rds certs as a sanity check
-RUN keytool -list -keystore /etc/ssl/certs/java/cacerts -storepass changeit -noprompt | grep -i rds
+RUN keytool -list -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit -noprompt | grep -i rds
 
 COPY target/smokefree-initiative-service*.jar smokefree-initiative-service.jar
 CMD java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar smokefree-initiative-service.jar


### PR DESCRIPTION
Docker image build was failed, by showing below error,

`Certificate was added to keystore
keytool error: java.io.FileNotFoundException: /etc/ssl/certs/java/cacerts (No such file or directory)
`

Now, pointing keystore to  `$JAVA_HOME/lib/security/cacerts` instead of `/etc/ssl/certs/java/cacerts` solve the issue.
