### PR TITLE
Fix unsupported renovation update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,7 +203,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.16</version>
+            <version>5.1.47</version>
         </dependency>
 
         <dependency>
@@ -239,7 +239,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-entitymanager</artifactId>
-            <version>5.2.18.Final</version>
+            <version>4.3.6.Final</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The following are the unsupported renovation updates,
1. hibernate entity manager 5+
2. mysql connector 8.0.16